### PR TITLE
index 구조 간단하게 변경

### DIFF
--- a/app.js
+++ b/app.js
@@ -102,7 +102,17 @@ const createFuzzyMatcher = input => {
 };
 
 const init = async () => {
-  const $searchSection = document.querySelector('.search-section');
+  const content = document.querySelector('.app');
+  const $searchSection = document.createElement('div');
+  $searchSection.className = 'search-section';
+  const $resultSection = document.createElement('div');
+  $resultSection.className = 'result-section';
+  $resultSection.innerHTML = `
+    <div class="file-title"></div>
+    <pre class="line-numbers"><code class="language-js"></code></pre>
+  `;
+  content.append($searchSection, $resultSection);
+  // const $searchSection = document.querySelector('.search-section');
   const searchInput = new SearchInput({ $target: $searchSection });
   searchInput.render();
   // renderSearchBox($searchSection);

--- a/components/Search/SearchResult.js
+++ b/components/Search/SearchResult.js
@@ -13,6 +13,7 @@ export function SearchResult({ $target, level, fileName }) {
   this.render = async () => {
     const fileContent = await getFileContent(level, fileName);
     const fileContentArr = textProcess(fileContent);
+    // const fileContentArr = fileContent;
     $target.innerHTML = fileContentArr;
   };
 }

--- a/index.html
+++ b/index.html
@@ -11,12 +11,12 @@
 
   <body>
     <h1>프로그래머스 풀이은행</h1>
-    <div class="content">
-      <div class="search-section"></div>
-      <div class="result-section">
+    <div class="app">
+      <!-- <div class="search-section"></div> -->
+      <!-- <div class="result-section">
         <div class="file-title"></div>
         <pre class="line-numbers"><code class="language-js"></code></pre>
-      </div>
+      </div> -->
     </div>
     <script src="app.js" type="module"></script>
     <script src="prism.js"></script>


### PR DESCRIPTION
기존에 api 관련 함수, 검색 관련 함수를 나누기로 하였는데,
경현님의 결과물과 겹치는 부분이 많아서 새로운 부분을 추가하였습니다.

## 처리한 항목
1. index.html에는 app, script를 제외하고 주석으로 변경하였고, app.js에 div를 생성하는 코드를 추가하였습니다.
2. SearchResult.js - textProcess의 경우 사용하지 않아도 동일하게 작동합니다. (코드는 그대로 두고, 주석으로 테스트할 수 있는 코드를 추가하였습니다.)

## 생각해야할 부분
1. 검색 시 해당하지 않는 문자열을 숨기는 형태인데, 이를 위해서는 모든 문제가 페이지에 있어야 합니다.  모든 사용자에게 모든 문제를 보여줄 필요는 없다고 생각합니다. 프로그래머스의 경우 20문제만 보여주고 사용자가 원하면 더 많은 문제를 보여줍니다. API에서 해당하는 문제를 가져오는 방법은 어떠신가요? 속도가 느리다면 좋은 방법이 있을까요?