### PR TITLE
복사버튼 css 추가 및 기타 자잘한 css 수정

### DIFF
--- a/Section/SearchBox/components/SearchableList.js
+++ b/Section/SearchBox/components/SearchableList.js
@@ -21,7 +21,7 @@ export function SearchableList() {
           ${POSSIBLE_LEVELS.map(
             level => `
           <ul class= "file-list ${`level-${level}`}">
-            [level ${level}]
+            Level ${level}
             ${fileList[level]
               .map(
                 file =>

--- a/Section/SearchResult/components/index.js
+++ b/Section/SearchResult/components/index.js
@@ -7,11 +7,11 @@ export default function SearchResult({ level, fileName }) {
   this.render = async () => {
     const $searchResult = document.querySelector('.searchResult');
     $searchResult.innerHTML = `
+      <div class="file-title"></div>
       <div class="solutionNavigator">
         <button class="btnPrevSolution-inactive">이전 해설</button>
         <button class="btnNextSolution">다음 해설</button>
       </div>
-      <div class="file-title"></div>
       <div>
         <pre class="code"></pre>
         <button class="btn-copy">코드 복사하기</button><span class="isCopied"></span>

--- a/Section/SearchResult/components/index.js
+++ b/Section/SearchResult/components/index.js
@@ -12,7 +12,7 @@ export default function SearchResult({ level, fileName }) {
         <button class="btnPrevSolution-inactive">이전 해설</button>
         <button class="btnNextSolution">다음 해설</button>
       </div>
-      <div>
+      <div class="code-area">
         <pre class="code"></pre>
         <button class="btn-copy">코드 복사하기</button><span class="isCopied"></span>
       </div>

--- a/styles/style.css
+++ b/styles/style.css
@@ -16,7 +16,7 @@ h1 {
 
 .app {
   display: flex;
-  width: 1200px;
+  width: 1050px;
   margin: 0 auto;
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -36,7 +36,7 @@ h1 {
 }
 
 .app .searchBox .searchableList .file-list {
-  font-size: 18px;
+  font-size: 20px;
   font-weight: 700;
   cursor: default;
   background-color: #e8f9fd;

--- a/styles/style.css
+++ b/styles/style.css
@@ -1,90 +1,115 @@
 * {
-  box-sizing: border-box; }
+  box-sizing: border-box;
+}
 
 body {
   background: white;
-  color: black; }
+  color: black;
+}
 
 h1 {
   text-align: center;
   margin: 50px 0;
-  color: black; }
+  color: black;
+}
 
 .app {
   display: flex;
   width: 1200px;
-  margin: 0 auto; }
-  .app .searchBox #searchInput {
-    width: 250px;
-    height: 50px;
-    color: black;
-    font-size: 18px;
-    border: 3px solid #2155CD;
-    border-radius: 15px;
-    outline: none;
-    padding: 0 10px; }
-  .app .searchBox .searchableList .file-list {
-    cursor: pointer;
-    background-color: #E8F9FD;
-    padding: 10px;
-    border: 0;
-    border-radius: 15px;
-    outline: none;
-    color: black; }
-    .app .searchBox .searchableList .file-list li {
-      padding: 5px;
-      list-style: none; }
-  .app .searchBox .searchableList .is-hidden {
-    display: none !important; }
-  .app .searchResult {
-    margin-left: 50px;
-    width: 800px; }
-    .app .searchResult .solutionNavigator {
-      display: flex;
-      float: right;
-      position: relative;
-      top: 55px; }
-      .app .searchResult .solutionNavigator > button {
-        width: 150px;
-        height: 50px;
-        text-align: center;
-        line-height: 50px;
-        margin: 5px;
-        border-radius: 30px;
-        font-size: 25px;
-        font-weight: 700;
-        border: 0;
-        background: linear-gradient(45deg, #0AA1DD, #2155CD);
-        color: white; }
-      .app .searchResult .solutionNavigator .btnPrevSolution,
-      .app .searchResult .solutionNavigator .btnNextSolution {
-        cursor: pointer; }
-      .app .searchResult .solutionNavigator .btnPrevSolution-inactive,
-      .app .searchResult .solutionNavigator .btnNextSolution-inactive {
-        opacity: 0.2; }
-    .app .searchResult .file-title {
-      display: flex;
-      align-items: center;
-      justify-content: center;
-      text-align: center;
-      background-color: #E8F9FD;
-      height: 50px;
-      line-height: 50px;
-      font-size: 30px;
-      position: relative;
-      border: 0;
-      border-radius: 15px;
-      outline: none;
-      color: black; }
-    .app .searchResult .code {
-      background-color: #E8F9FD;
-      padding: 10px;
-      margin-top: 70px;
-      width: 100%;
-      overflow-x: auto;
-      border: 0;
-      border-radius: 15px;
-      outline: none;
-      color: black; }
+  margin: 0 auto;
+}
 
-/*# sourceMappingURL=style.css.map */
+.app .searchBox #searchInput {
+  width: 250px;
+  height: 50px;
+  color: black;
+  font-size: 18px;
+  border: 3px solid #2155cd;
+  border-radius: 15px;
+  outline: none;
+  padding: 0 10px;
+}
+
+.app .searchBox .searchableList .file-list {
+  cursor: default;
+  background-color: #e8f9fd;
+  padding: 10px;
+  border: 0;
+  border-radius: 15px;
+  outline: none;
+  color: black;
+}
+
+.app .searchBox .searchableList .file-list li {
+  cursor: pointer;
+  padding: 5px;
+  list-style: none;
+}
+
+.app .searchBox .searchableList .is-hidden {
+  display: none !important;
+}
+
+.app .searchResult {
+  margin-left: 50px;
+  width: 800px;
+}
+
+.app .searchResult .solutionNavigator {
+  display: flex;
+  float: right;
+  position: relative;
+  top: 55px;
+}
+
+.app .searchResult .solutionNavigator > button {
+  width: 150px;
+  height: 50px;
+  text-align: center;
+  line-height: 50px;
+  margin: 5px;
+  border-radius: 30px;
+  font-size: 25px;
+  font-weight: 700;
+  border: 0;
+  background: linear-gradient(45deg, #0aa1dd, #2155cd);
+  color: white;
+}
+
+.app .searchResult .solutionNavigator .btnPrevSolution,
+.app .searchResult .solutionNavigator .btnNextSolution {
+  cursor: pointer;
+}
+
+.app .searchResult .solutionNavigator .btnPrevSolution-inactive,
+.app .searchResult .solutionNavigator .btnNextSolution-inactive {
+  opacity: 0.2;
+}
+
+.app .searchResult .file-title {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  background-color: #e8f9fd;
+  height: 50px;
+  line-height: 50px;
+  font-size: 30px;
+  position: relative;
+  border: 0;
+  border-radius: 15px;
+  outline: none;
+  color: black;
+}
+
+.app .searchResult .code {
+  background-color: #e8f9fd;
+  padding: 10px;
+  margin-top: 70px;
+  width: 100%;
+  overflow-x: auto;
+  border: 0;
+  border-radius: 15px;
+  outline: none;
+  color: black;
+}

--- a/styles/style.css
+++ b/styles/style.css
@@ -8,6 +8,7 @@ body {
 }
 
 h1 {
+  cursor: default;
   text-align: center;
   margin: 50px 0;
   color: black;

--- a/styles/style.css
+++ b/styles/style.css
@@ -66,9 +66,7 @@ h1 {
 }
 
 .app .searchResult button {
-  height: 50px;
   text-align: center;
-  line-height: 50px;
   margin: 5px;
   border-radius: 30px;
   font-size: 25px;
@@ -85,7 +83,10 @@ h1 {
 }
 
 .app .searchResult .solutionNavigator button {
+  height: 50px;
   width: 150px;
+  line-height: 50px;
+  font-size: 25px;
 }
 
 .app .searchResult .solutionNavigator .btnPrevSolution-inactive,
@@ -108,7 +109,13 @@ h1 {
   color: black;
 }
 
-.app .searchResult .code {
+.app .searchResult .code-area {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.app .searchResult .code-area .code {
   background-color: #e8f9fd;
   padding: 10px;
   margin: 0;
@@ -120,6 +127,9 @@ h1 {
   color: black;
 }
 
-.app .searchResult .btn-copy {
-  width: 200px;
+.app .searchResult .code-area .btn-copy {
+  height: 40px;
+  width: 150px;
+  line-height: 40px;
+  font-size: 20px;
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -56,15 +56,7 @@ h1 {
   width: 800px;
 }
 
-.app .searchResult .solutionNavigator {
-  display: flex;
-  float: right;
-  position: relative;
-  top: 55px;
-}
-
-.app .searchResult .solutionNavigator > button {
-  width: 150px;
+.app .searchResult button {
   height: 50px;
   text-align: center;
   line-height: 50px;
@@ -75,15 +67,23 @@ h1 {
   border: 0;
   background: linear-gradient(45deg, #0aa1dd, #2155cd);
   color: white;
+  cursor: pointer;
 }
 
-.app .searchResult .solutionNavigator .btnPrevSolution,
-.app .searchResult .solutionNavigator .btnNextSolution {
-  cursor: pointer;
+.app .searchResult .solutionNavigator {
+  display: flex;
+  float: right;
+  position: relative;
+  top: 55px;
+}
+
+.app .searchResult .solutionNavigator button {
+  width: 150px;
 }
 
 .app .searchResult .solutionNavigator .btnPrevSolution-inactive,
 .app .searchResult .solutionNavigator .btnNextSolution-inactive {
+  cursor: none;
   opacity: 0.2;
 }
 
@@ -113,4 +113,8 @@ h1 {
   border-radius: 15px;
   outline: none;
   color: black;
+}
+
+.app .searchResult .btn-copy {
+  width: 200px;
 }

--- a/styles/style.css
+++ b/styles/style.css
@@ -32,6 +32,8 @@ h1 {
 }
 
 .app .searchBox .searchableList .file-list {
+  font-size: 18px;
+  font-weight: 700;
   cursor: default;
   background-color: #e8f9fd;
   padding: 10px;
@@ -42,9 +44,16 @@ h1 {
 }
 
 .app .searchBox .searchableList .file-list li {
+  font-size: 16px;
+  font-weight: normal;
   cursor: pointer;
   padding: 5px;
   list-style: none;
+}
+
+.app .searchBox .searchableList .file-list :first-of-type {
+  border-top: 0.9px solid gray;
+  margin-top: 5px;
 }
 
 .app .searchBox .searchableList .is-hidden {

--- a/styles/style.css
+++ b/styles/style.css
@@ -81,9 +81,7 @@ h1 {
 
 .app .searchResult .solutionNavigator {
   display: flex;
-  float: right;
-  position: relative;
-  top: 55px;
+  justify-content: end;
 }
 
 .app .searchResult .solutionNavigator button {
@@ -97,9 +95,7 @@ h1 {
 }
 
 .app .searchResult .file-title {
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  margin-bottom: 10px;
   text-align: center;
   background-color: #e8f9fd;
   height: 50px;
@@ -115,7 +111,7 @@ h1 {
 .app .searchResult .code {
   background-color: #e8f9fd;
   padding: 10px;
-  margin-top: 70px;
+  margin: 0;
   width: 100%;
   overflow-x: auto;
   border: 0;

--- a/styles/style.css
+++ b/styles/style.css
@@ -92,7 +92,7 @@ h1 {
 
 .app .searchResult .solutionNavigator .btnPrevSolution-inactive,
 .app .searchResult .solutionNavigator .btnNextSolution-inactive {
-  cursor: none;
+  cursor: not-allowed;
   opacity: 0.2;
 }
 

--- a/styles/style.css
+++ b/styles/style.css
@@ -25,10 +25,14 @@ h1 {
   height: 50px;
   color: black;
   font-size: 18px;
-  border: 3px solid #2155cd;
+  border: 3px solid #0aa1dd;
   border-radius: 15px;
   outline: none;
   padding: 0 10px;
+}
+
+.app .searchBox #searchInput:focus {
+  border: 3px solid #2155cd;
 }
 
 .app .searchBox .searchableList .file-list {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -27,6 +27,7 @@ body {
   color: $text-color;
 }
 h1 {
+  cursor: default;
   text-align: center;
   margin: 50px 0;
   color: $text-color;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -52,6 +52,8 @@ h1 {
     }
     .searchableList {
       .file-list {
+        font-size: 18px;
+        font-weight: 700;
         cursor: default;
         background-color: $bg-color;
         padding: 10px;
@@ -59,11 +61,16 @@ h1 {
         border-radius: 15px;
         outline: none;
         color: $text-color;
-
         li {
+          font-size: 16px;
+          font-weight: normal;
           cursor: pointer;
           padding: 5px;
           list-style: none;
+        }
+        :first-of-type {
+          border-top: 0.9px solid gray;
+          margin-top: 5px;
         }
       }
       .is-hidden {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -56,7 +56,7 @@ h1 {
     }
     .searchableList {
       .file-list {
-        font-size: 18px;
+        font-size: 20px;
         font-weight: 700;
         cursor: default;
         background-color: $bg-color;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -97,9 +97,7 @@ h1 {
     }
     .solutionNavigator {
       display: flex;
-      float: right;
-      position: relative;
-      top: 55px;
+      justify-content: end;
       button {
         width: 150px;
       }
@@ -110,16 +108,13 @@ h1 {
       }
     }
     .file-title {
-      display: flex;
-      align-items: center;
-      justify-content: center;
+      margin-bottom: 10px;
       text-align: center;
       background-color: $bg-color;
       height: 50px;
       line-height: 50px;
       font-size: 30px;
       position: relative;
-      // width: 100px;
       border: 0;
       border-radius: 15px;
       outline: none;
@@ -128,7 +123,7 @@ h1 {
     .code {
       background-color: $bg-color;
       padding: 10px;
-      margin-top: 70px;
+      margin: 0;
       width: 100%;
       overflow-x: auto;
       border: 0;

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -105,7 +105,7 @@ h1 {
       }
       .btnPrevSolution-inactive,
       .btnNextSolution-inactive {
-        cursor: none;
+        cursor: not-allowed;
         opacity: 0.2;
       }
     }

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -83,9 +83,7 @@ h1 {
     margin-left: 50px;
     width: 800px;
     button {
-      height: 50px;
       text-align: center;
-      line-height: 50px;
       margin: 5px;
       border-radius: 30px;
       font-size: 25px;
@@ -99,7 +97,10 @@ h1 {
       display: flex;
       justify-content: end;
       button {
+        height: 50px;
         width: 150px;
+        line-height: 50px;
+        font-size: 25px;
       }
       .btnPrevSolution-inactive,
       .btnNextSolution-inactive {
@@ -120,19 +121,27 @@ h1 {
       outline: none;
       color: $text-color;
     }
-    .code {
-      background-color: $bg-color;
-      padding: 10px;
-      margin: 0;
-      width: 100%;
-      overflow-x: auto;
-      border: 0;
-      border-radius: 15px;
-      outline: none;
-      color: $text-color;
-    }
-    .btn-copy {
-      width: 200px;
+    .code-area {
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+      .code {
+        background-color: $bg-color;
+        padding: 10px;
+        margin: 0;
+        width: 100%;
+        overflow-x: auto;
+        border: 0;
+        border-radius: 15px;
+        outline: none;
+        color: $text-color;
+      }
+      .btn-copy {
+        height: 40px;
+        width: 150px;
+        line-height: 40px;
+        font-size: 20px;
+      }
     }
   }
 }

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -35,7 +35,7 @@ h1 {
 
 .app {
   display: flex;
-  width: 1200px;
+  width: 1050px;
   margin: 0 auto;
   //searchBox
   .searchBox {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -75,30 +75,30 @@ h1 {
   .searchResult {
     margin-left: 50px;
     width: 800px;
+    button {
+      height: 50px;
+      text-align: center;
+      line-height: 50px;
+      margin: 5px;
+      border-radius: 30px;
+      font-size: 25px;
+      font-weight: 700;
+      border: 0;
+      background: linear-gradient(45deg, $bg-btn1, $bg-btn2);
+      color: $text-btn;
+      cursor: pointer;
+    }
     .solutionNavigator {
       display: flex;
       float: right;
       position: relative;
       top: 55px;
-      > button {
+      button {
         width: 150px;
-        height: 50px;
-        text-align: center;
-        line-height: 50px;
-        margin: 5px;
-        border-radius: 30px;
-        font-size: 25px;
-        font-weight: 700;
-        border: 0;
-        background: linear-gradient(45deg, $bg-btn1, $bg-btn2);
-        color: $text-btn;
-      }
-      .btnPrevSolution,
-      .btnNextSolution {
-        cursor: pointer;
       }
       .btnPrevSolution-inactive,
       .btnNextSolution-inactive {
+        cursor: none;
         opacity: 0.2;
       }
     }
@@ -130,6 +130,7 @@ h1 {
       color: $text-color;
     }
     .btn-copy {
+      width: 200px;
     }
   }
 }

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -1,7 +1,8 @@
 ////화이트모드
 // $bg-color: #ecf0f1;
 $bg-color: #e8f9fd;
-$border: #2155cd;
+$border1: #0aa1dd;
+$border2: #2155cd;
 $text-color: black;
 $text-btn: white;
 $background: white;
@@ -45,10 +46,13 @@ h1 {
       //background-color: $bg-color;
       color: $text-color;
       font-size: 18px;
-      border: 3px solid $border;
+      border: 3px solid $border1;
       border-radius: 15px;
       outline: none;
       padding: 0 10px;
+      &:focus {
+        border: 3px solid $border2;
+      }
     }
     .searchableList {
       .file-list {

--- a/styles/style.scss
+++ b/styles/style.scss
@@ -1,14 +1,14 @@
 ////화이트모드
 // $bg-color: #ecf0f1;
- $bg-color: #E8F9FD;
- $border: #2155CD;
- $text-color: black;
- $text-btn: white;
- $background: white;
- //$bg-btn1: #ff7675;
- $bg-btn1: #0AA1DD;
- //$bg-btn2: #e84393;
- $bg-btn2: #2155CD;
+$bg-color: #e8f9fd;
+$border: #2155cd;
+$text-color: black;
+$text-btn: white;
+$background: white;
+//$bg-btn1: #ff7675;
+$bg-btn1: #0aa1dd;
+//$bg-btn2: #e84393;
+$bg-btn2: #2155cd;
 
 //블랙모드
 //$bg-color: #263747;
@@ -24,7 +24,7 @@
 
 body {
   background: $background;
-  color: $text-color
+  color: $text-color;
 }
 h1 {
   text-align: center;
@@ -51,7 +51,7 @@ h1 {
     }
     .searchableList {
       .file-list {
-        cursor: pointer;
+        cursor: default;
         background-color: $bg-color;
         padding: 10px;
         border: 0;
@@ -60,6 +60,7 @@ h1 {
         color: $text-color;
 
         li {
+          cursor: pointer;
           padding: 5px;
           list-style: none;
         }
@@ -101,7 +102,7 @@ h1 {
       }
     }
     .file-title {
-      display:flex;
+      display: flex;
       align-items: center;
       justify-content: center;
       text-align: center;
@@ -127,8 +128,7 @@ h1 {
       outline: none;
       color: $text-color;
     }
-    .btn-copy{
-
+    .btn-copy {
     }
   }
 }


### PR DESCRIPTION
## 변동사항
- 커서 관련: Level N 부분 pointer -> default, 제목 부분 auto -> default, 비활성화된 버튼: pointer -> not-allowed
- 복사버튼 css 추가 및 배치 변경
- .app 부분 가운데정렬을 위한 크기 조정
- 문제리스트의 Level N과 문제 이름 부분을 구분선으로 구분
- Level N 표시방식 변경([level N] -> Level N) 및 텍스트 강조
- title 중앙정렬
- 검색창 focus시 border 색상 강조

## 제안사항
- 현재 HTML title(프로그래머스 풀이은행)과 제목(프로그래머스 해설 은행🔍") 불일치 -> 통일 필요
- 저희 깃허브 링크로 연결되는 버튼을 추가하는게 어떨까요?
- 코드의 글씨 크기가 너무 작게 느껴지지는 않나요?
- 버튼의 그라디언트가 코드 복사하기 버튼에까지 적용되니 시선이 많이 분산되는 것 같은데, 복사하기 버튼만 다른 디자인을 적용하는 것이 좋을까요? 아니면 전체적으로 그라디언트를 없애는 것이 좋을까요?
- class 명명규칙의 통일이 필요해보입니다. 원래 규칙은 단어와 단어 사이를 하이픈으로 연결해야 하지만, 지난번에 경현님이 말씀해주신 단점도 있으니 하나로 결정해서 통일했으면 좋겠습니다.